### PR TITLE
Add simulated device capability

### DIFF
--- a/config.ts
+++ b/config.ts
@@ -1,4 +1,4 @@
 export default {
     name: 'Rower',
-    socketServerUrl: 'http://192.168.0.9:8080'
+    socketServerUrl: 'http://localhost:8080'
 };

--- a/config.ts
+++ b/config.ts
@@ -1,4 +1,5 @@
 export default {
     name: 'Rower',
-    socketServerUrl: 'http://localhost:8080'
+    socketServerUrl: 'http://localhost:8080',
+    simulationMode: false
 };

--- a/index.ts
+++ b/index.ts
@@ -9,10 +9,11 @@ import { WaterRower } from 'waterrower';
 let waterrower = new WaterRower();
 
 //command line arguments
-let rowerName = (args["n"] ? args["n"] : (config.name ? config.name : 'Rower'));
-let socketServerUrl = (args["s"] ? args["s"] : (config.socketServerUrl ? config.socketServerUrl : 'http://localhost:8080'));
+let name = args["n"] || args["name"] || config.name || 'Rower';
+let socketServerUrl = args["s"] || args["socket-server-url"] || config.socketServerUrl || 'http://localhost:8080';
+let simulationMode = args["m"] || args["simulation-mode"] || config.simulationMode;
 
-console.log(`Using ${rowerName} as rower name.`);
+console.log(`Using ${name} as rower name.`);
 console.log(`Attempting to connect to ${socketServerUrl}`);
 
 //wire up to the socket server
@@ -21,6 +22,7 @@ socket.on("message", data => {
     if (data.message == 'startrace') {
         waterrower.reset();
         waterrower.defineDistanceWorkout(data.distance);
+        if(simulationMode) waterrower.startSimulation();
     }
 });
 
@@ -28,7 +30,7 @@ socket.on("message", data => {
 waterrower.datapoints$.subscribe(() => {
     socket.send({
         message: "strokedata",
-        name: rowerName,
+        name: name,
         distance: waterrower.requestDataPoint('distance'),
         strokeRate: waterrower.requestDataPoint('strokes_cnt'),
         speed: waterrower.requestDataPoint('m_s_total'),

--- a/package.json
+++ b/package.json
@@ -14,6 +14,9 @@
     "socket.io-client": "^1.3.7",
     "waterrower": "^0.4.0"
   },
+  "files":[
+    "data/simulationdata"
+  ],
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "start": "nodemon index.js"


### PR DESCRIPTION
This allows you to use a command line parameter or a config option to tell the device to go into simulation mode. This simply tells the `waterrower` module to start simulation and the device project should start getting data as if a person were rowing. Tested at the command line.